### PR TITLE
fix: console error in ClubMatchResults.js

### DIFF
--- a/src/components/ClubMatchResults.js
+++ b/src/components/ClubMatchResults.js
@@ -18,7 +18,7 @@ const ClubMatchResults = () => {
   return (
     <Row xs={1} md={2} className="g-4">
       {club_match_results.map(club_match_result => (
-        <Col>
+        <Col key={club_match_result.opponent_name}>
           <Image className="emblem" src={`${process.env.PUBLIC_URL}/my_page_header.jpeg`} roundedCircle />
           {club_match_result.opponent_name}：{club_match_result.win}勝{club_match_result.lose}敗{club_match_result.draw}分
         </Col>

--- a/src/components/ClubMatchResults.js
+++ b/src/components/ClubMatchResults.js
@@ -1,12 +1,14 @@
 import {Row,Col,Image} from "react-bootstrap"
 const club_match_results = [
   {
+    club_id: 1,
     opponent_name: "鹿島アントラーズ",
     win: 99,
     lose: 0,
     draw: 1,
   },
   {
+    club_id: 2,
     opponent_name: "ガンバ大阪",
     win: 49,
     lose: 49,
@@ -18,7 +20,7 @@ const ClubMatchResults = () => {
   return (
     <Row xs={1} md={2} className="g-4">
       {club_match_results.map(club_match_result => (
-        <Col key={club_match_result.opponent_name}>
+        <Col key={club_match_result.club_id}>
           <Image className="emblem" src={`${process.env.PUBLIC_URL}/my_page_header.jpeg`} roundedCircle />
           {club_match_result.opponent_name}：{club_match_result.win}勝{club_match_result.lose}敗{club_match_result.draw}分
         </Col>


### PR DESCRIPTION
目的：
src/components/ClubMatchResults.jsで発生していたJavaScriptエラーを修正。
![Before](https://user-images.githubusercontent.com/28209852/127938725-024a0e4f-682f-47bb-9525-f62e98882cd1.png)

修正内容：
配列の要素にkeyを追加。
以下を参照し対応。
https://ja.reactjs.org/docs/lists-and-keys.html#gatsby-focus-wrapper

結果：
エラーが5件から4件へ。当該エラーも発生しない。
![After](https://user-images.githubusercontent.com/28209852/127938859-8fdd5556-6ed3-4b2c-a466-15b94bd213e3.png)