### PR TITLE
feat: add team_name in support_info

### DIFF
--- a/src/components/SupportInfo.js
+++ b/src/components/SupportInfo.js
@@ -9,8 +9,7 @@ const SupportInfo = ({support_info}) => {
       <Row>
         <Col>
           <Image className="emblem" src={`${process.env.PUBLIC_URL}/my_page_header.jpeg`} roundedCircle />
-          <h6>応援しているチーム</h6>
-          <h6>{JSON.stringify(support_info)}</h6>
+          <h6>{`応援しているチーム：${support_info.team_name}`}</h6>
         </Col>
         <Col>
           <Row><h6>{`${support_info.win}勝${support_info.lose}敗${support_info.draw}分`}</h6></Row>


### PR DESCRIPTION
## 目的
- マイページの「応援しているチーム」ラベルの右に、実際に応援しているチームを表示する。
- 「応援しているチーム」の下部に取得したsupport_infoのJSONがそのまま表示されていたので削除。

## 影響範囲
- footlog-api/app/models/user.rb
- footlog-frontend/src/components/SupportInfo.js

## テスト内容
usersテーブルのclub_idを変えてチーム名が変わることを確認済み。